### PR TITLE
refactor(client): Migrate from Apollo boost and rework refresh token logic

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -9,7 +9,9 @@
     "@types/react": "16.9.5",
     "@types/react-dom": "16.9.1",
     "apollo-boost": "^0.4.4",
+    "apollo-link-token-refresh": "^0.2.6",
     "graphql": "^14.5.8",
+    "jwt-decode": "^2.2.0",
     "react": "^16.10.2",
     "react-dom": "^16.10.2",
     "react-scripts": "3.2.0",
@@ -39,10 +41,11 @@
   },
   "devDependencies": {
     "@graphql-codegen/cli": "^1.8.0",
-    "@types/graphql": "^14.5.0",
+    "@graphql-codegen/introspection": "1.8.0",
     "@graphql-codegen/typescript": "1.8.0",
     "@graphql-codegen/typescript-operations": "1.8.0",
     "@graphql-codegen/typescript-react-apollo": "1.8.0",
-    "@graphql-codegen/introspection": "1.8.0"
+    "@types/graphql": "^14.5.0",
+    "@types/jwt-decode": "^2.2.1"
   }
 }

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,0 +1,29 @@
+import React, { FC, useState, useEffect } from 'react';
+import Routes from './Routes';
+import { setAccessToken } from './accessToken';
+
+export interface AppProps {}
+
+const App: FC<AppProps> = props => {
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetch('http://localhost:4000/refresh_token', {
+      credentials: 'include',
+      method: 'POST',
+    })
+      .then(res => res.json())
+      .then(({ accessToken }) => {
+        setAccessToken(accessToken);
+        setLoading(false);
+      });
+  }, []);
+
+  if (loading) {
+    return <div> Loading!!! </div>;
+  }
+
+  return <Routes />;
+};
+
+export default App;

--- a/client/src/Routes.tsx
+++ b/client/src/Routes.tsx
@@ -3,6 +3,7 @@ import { BrowserRouter, Switch, Route, Link } from 'react-router-dom';
 import Home from './pages/Home';
 import Register from './pages/Register';
 import Login from './pages/Login';
+import Bye from './pages/Bye';
 
 const Routes: React.FC = () => {
   return (
@@ -13,13 +14,20 @@ const Routes: React.FC = () => {
             <Link to="/register"> Register </Link>
           </div>
           <div>
-            <Link to="login"> Login </Link>
+            <Link to="/login"> Login </Link>
+          </div>
+          <div>
+            <Link to="/"> Home </Link>
+          </div>
+          <div>
+            <Link to="/bye"> Bye </Link>
           </div>
         </header>
         <Switch>
           <Route exact path="/" component={Home} />
           <Route exact path="/register" component={Register} />
           <Route exact path="/login" component={Login} />
+          <Route exact path="/bye" component={Bye} />
         </Switch>
       </div>
     </BrowserRouter>

--- a/client/src/accessToken.ts
+++ b/client/src/accessToken.ts
@@ -1,0 +1,9 @@
+let accessToken = '';
+
+export const setAccessToken = (token: string) => {
+  if (token) {
+    accessToken = token;
+  }
+};
+
+export const getAccessToken = () => accessToken;

--- a/client/src/generated/graphql.tsx
+++ b/client/src/generated/graphql.tsx
@@ -53,12 +53,34 @@ export type User = {
   email: Scalars['String'],
 };
 
+export type ByeQueryVariables = {};
+
+
+export type ByeQuery = (
+  { __typename?: 'Query' }
+  & Pick<Query, 'bye'>
+);
+
 export type HelloQueryVariables = {};
 
 
 export type HelloQuery = (
   { __typename?: 'Query' }
   & Pick<Query, 'hello'>
+);
+
+export type LoginMutationVariables = {
+  email: Scalars['String'],
+  password: Scalars['String']
+};
+
+
+export type LoginMutation = (
+  { __typename?: 'Mutation' }
+  & { login: (
+    { __typename?: 'LoginResponse' }
+    & Pick<LoginResponse, 'accessToken'>
+  ) }
 );
 
 export type RegisterMutationVariables = {
@@ -84,6 +106,36 @@ export type UsersQuery = (
 );
 
 
+export const ByeDocument = gql`
+    query Bye {
+  bye
+}
+    `;
+
+/**
+ * __useByeQuery__
+ *
+ * To run a query within a React component, call `useByeQuery` and pass it any options that fit your needs.
+ * When your component renders, `useByeQuery` returns an object from Apollo Client that contains loading, error, and data properties 
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useByeQuery({
+ *   variables: {
+ *   },
+ * });
+ */
+export function useByeQuery(baseOptions?: ApolloReactHooks.QueryHookOptions<ByeQuery, ByeQueryVariables>) {
+        return ApolloReactHooks.useQuery<ByeQuery, ByeQueryVariables>(ByeDocument, baseOptions);
+      }
+export function useByeLazyQuery(baseOptions?: ApolloReactHooks.LazyQueryHookOptions<ByeQuery, ByeQueryVariables>) {
+          return ApolloReactHooks.useLazyQuery<ByeQuery, ByeQueryVariables>(ByeDocument, baseOptions);
+        }
+export type ByeQueryHookResult = ReturnType<typeof useByeQuery>;
+export type ByeLazyQueryHookResult = ReturnType<typeof useByeLazyQuery>;
+export type ByeQueryResult = ApolloReactCommon.QueryResult<ByeQuery, ByeQueryVariables>;
 export const HelloDocument = gql`
     query Hello {
   hello
@@ -114,6 +166,39 @@ export function useHelloLazyQuery(baseOptions?: ApolloReactHooks.LazyQueryHookOp
 export type HelloQueryHookResult = ReturnType<typeof useHelloQuery>;
 export type HelloLazyQueryHookResult = ReturnType<typeof useHelloLazyQuery>;
 export type HelloQueryResult = ApolloReactCommon.QueryResult<HelloQuery, HelloQueryVariables>;
+export const LoginDocument = gql`
+    mutation Login($email: String!, $password: String!) {
+  login(email: $email, password: $password) {
+    accessToken
+  }
+}
+    `;
+export type LoginMutationFn = ApolloReactCommon.MutationFunction<LoginMutation, LoginMutationVariables>;
+
+/**
+ * __useLoginMutation__
+ *
+ * To run a mutation, you first call `useLoginMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useLoginMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [loginMutation, { data, loading, error }] = useLoginMutation({
+ *   variables: {
+ *      email: // value for 'email'
+ *      password: // value for 'password'
+ *   },
+ * });
+ */
+export function useLoginMutation(baseOptions?: ApolloReactHooks.MutationHookOptions<LoginMutation, LoginMutationVariables>) {
+        return ApolloReactHooks.useMutation<LoginMutation, LoginMutationVariables>(LoginDocument, baseOptions);
+      }
+export type LoginMutationHookResult = ReturnType<typeof useLoginMutation>;
+export type LoginMutationResult = ApolloReactCommon.MutationResult<LoginMutation>;
+export type LoginMutationOptions = ApolloReactCommon.BaseMutationOptions<LoginMutation, LoginMutationVariables>;
 export const RegisterDocument = gql`
     mutation Register($email: String!, $password: String!) {
   register(email: $email, password: $password)

--- a/client/src/graphql/bye.graphql
+++ b/client/src/graphql/bye.graphql
@@ -1,0 +1,3 @@
+query Bye {
+  bye
+}

--- a/client/src/graphql/login.graphql
+++ b/client/src/graphql/login.graphql
@@ -1,0 +1,5 @@
+mutation Login($email: String!, $password: String!) {
+  login(email: $email, password: $password) {
+    accessToken
+  }
+}

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -1,17 +1,107 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import ApolloClient from 'apollo-boost';
 import { ApolloProvider } from '@apollo/react-hooks';
 
-import Routes from './Routes';
+import { getAccessToken, setAccessToken } from './accessToken';
+import App from './App';
+
+import { ApolloClient } from 'apollo-client';
+import { InMemoryCache } from 'apollo-cache-inmemory';
+import { HttpLink } from 'apollo-link-http';
+import { onError } from 'apollo-link-error';
+import { ApolloLink, Observable } from 'apollo-link';
+import { TokenRefreshLink } from 'apollo-link-token-refresh';
+import JwtDecode from 'jwt-decode';
+
+const cache = new InMemoryCache({});
+
+const requestLink = new ApolloLink(
+  (operation, forward) =>
+    new Observable(observer => {
+      let handle: any;
+      Promise.resolve(operation)
+        .then(operation => {
+          const accessToken = getAccessToken();
+
+          if (accessToken) {
+            operation.setContext({
+              headers: {
+                authorization: `Bearer ${getAccessToken()}`,
+              },
+            });
+          }
+        })
+        .then(() => {
+          handle = forward(operation).subscribe({
+            next: observer.next.bind(observer),
+            error: observer.error.bind(observer),
+            complete: observer.complete.bind(observer),
+          });
+        })
+        .catch(observer.error.bind(observer));
+
+      return () => {
+        if (handle) handle.unsubscribe();
+      };
+    })
+);
 
 const client = new ApolloClient({
-  uri: 'http://localhost:4000/graphql',
+  link: ApolloLink.from([
+    new TokenRefreshLink({
+      accessTokenField: 'accessToken',
+      isTokenValidOrUndefined: () => {
+        const token = getAccessToken();
+
+        if (!token) {
+          return true;
+        }
+
+        try {
+          // exp property is automatically added to the token once it expires (?)
+          const { exp } = JwtDecode(token);
+
+          if (Date.now() >= exp * 1000) {
+            return false;
+          }
+
+          return true;
+        } catch (err) {
+          return false;
+        }
+      },
+      fetchAccessToken: () =>
+        fetch('http://localhost:4000/refresh_token', {
+          credentials: 'include',
+          method: 'POST',
+        }),
+      handleFetch: accessToken => setAccessToken(accessToken),
+      handleError: err => {
+        // full control over handling token fetch Error
+        console.warn('Your refresh token is invalid. Try to relogin');
+        console.error(err);
+      },
+    }),
+    onError(({ graphQLErrors, networkError }) => {
+      if (graphQLErrors) {
+        console.log('(graphQLErrors)', graphQLErrors);
+      }
+      if (networkError) {
+        console.log('(networkError)', networkError);
+      }
+    }),
+    requestLink,
+    new HttpLink({
+      uri: 'http://localhost:4000/graphql',
+      credentials: 'include',
+    }),
+  ]),
+  cache,
 });
 
 ReactDOM.render(
   <ApolloProvider client={client}>
-    <Routes />
+    <App />
   </ApolloProvider>,
   document.getElementById('root')
 );

--- a/client/src/pages/Bye.tsx
+++ b/client/src/pages/Bye.tsx
@@ -1,0 +1,23 @@
+import React, { FC } from 'react';
+import { useByeQuery } from '../generated/graphql';
+
+export interface ByeProps {}
+
+const Bye: FC<ByeProps> = props => {
+  const { data, loading, error } = useByeQuery();
+
+  if (loading) return <p> Loading!!! </p>;
+
+  if (error) {
+    console.log('ERROR', error);
+    return <p>Error: {JSON.stringify(error)} </p>;
+  }
+
+  if (!data) {
+    return <p> No Data! </p>;
+  }
+
+  return <p>Bye! {data.bye} </p>;
+};
+
+export default Bye;

--- a/client/src/pages/Login.tsx
+++ b/client/src/pages/Login.tsx
@@ -1,9 +1,49 @@
-import React, { FC } from 'react';
+import React, { FC, useState } from 'react';
+import { RouteComponentProps } from 'react-router-dom';
+import { useLoginMutation } from '../generated/graphql';
+import { setAccessToken } from '../accessToken';
 
-export interface LoginProps {}
+const Login: FC<RouteComponentProps> = ({ history }) => {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [login] = useLoginMutation();
 
-const Login: FC<LoginProps> = props => {
-  return <div> Login Page!!! </div>;
+  return (
+    <form
+      onSubmit={async e => {
+        e.preventDefault();
+        console.log(email, password);
+        const { data } = await login({ variables: { email, password } });
+        console.log('Form submitted!!!', data);
+
+        if (data && data.login) {
+          setAccessToken(data.login.accessToken);
+        }
+
+        history.push('/');
+      }}
+    >
+      <div>
+        <input
+          type="email"
+          value={email}
+          placeholder="Email"
+          onChange={e => setEmail(e.target.value)}
+        />
+      </div>
+      <div>
+        <input
+          type="password"
+          value={password}
+          placeholder="Password"
+          onChange={e => setPassword(e.target.value)}
+        />
+      </div>
+      <div>
+        <button type="submit"> Login </button>
+      </div>
+    </form>
+  );
 };
 
 export default Login;


### PR DESCRIPTION
Switched to separate Apollo config instead of using unified Apollo Bost, as it's more customizable. Configured Login page, and refactored refresh token logic to be used through the `apollo-link-token-refresh` library.